### PR TITLE
Remove rule  linebreak style

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -62,10 +62,6 @@
             "error",
             2
         ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
         "quotes": [
             "error",
             "single",

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
Al crear un archivo en un SO de Windows este utiliza el End Of Line CRLF mientras que Git utiliza LF (por defecto) causando que Git los trate como cambios en el archivo, ademas de que ESlint lance warnings.
Este PR remueve la regla y soluciona los problemas antes mencionados.

Mas información acerca de los **End Of Line** o **Line Endings**: https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git/